### PR TITLE
Add date to logging in order to search error log easily. 

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,7 @@ WantTo::Application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.logger = Logger.new(config.paths["log"].first)
+  config.logger.formatter = Logger::Formatter.new
 end


### PR DESCRIPTION
This has no trello backlog.
