### PR TITLE
fix #61 y軸のラベルと目盛りの数字が重なって表示される

### DIFF
--- a/app/views/home/movie.html.erb
+++ b/app/views/home/movie.html.erb
@@ -130,9 +130,9 @@
                .attr("class", "y axis")
                .call(yAxis)
                .append("text")
+               .attr("y", -10)
                .style("text-anchor", "end")
                .text("盛り上がり")
-
 
             </script>
         </div>


### PR DESCRIPTION
fix #61 

<img width="1280" alt="2015-10-31 15 02 39" src="https://cloud.githubusercontent.com/assets/8910941/10862166/dc5b9900-7fe0-11e5-8786-5ac52dd60eba.png">
