### PR TITLE
bookmarkテーブルを追加

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,2 @@
+class Bookmark < ActiveRecord::Base
+end

--- a/db/migrate/20151031132644_create_bookmarks.rb
+++ b/db/migrate/20151031132644_create_bookmarks.rb
@@ -4,7 +4,7 @@ class CreateBookmarks < ActiveRecord::Migration
       t.string :smid, null: false
       t.integer :start_vpos, null: false
       t.text :comment
-      t.text :tag
+      # t.text :tag
       t.timestamps null: false
     end
   end

--- a/db/migrate/20151031132644_create_bookmarks.rb
+++ b/db/migrate/20151031132644_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration
+  def change
+    create_table :bookmarks do |t|
+      t.string :smid, null: false
+      t.integer :start_vpos, null: false
+      t.text :comment
+      t.text :tag
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BookmarkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
テーブルだけ作りました。
rake db:migrateをすると反映されます。

テーブル名：bookmark

| カラム名 | 型 | 制約 |
| :-: | :-: | :-: |
| smid | string | notnull |
| start_vpos | integer | notnull |
| tag | text |  |
| comment | text |  |

ユーザーはテーブル作成後追加します。
