### PR TITLE
improve closed error message

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -74,20 +74,24 @@ class HomeController < ApplicationController
     cookie = login_nicovideo(ENV["NICOADD"], ENV["NICOPASS"])
     flv_info = get_flv_info(cookie, @id)
     
+    if flv_info.key? :closed
+      logger.info flv_info
+      flash[:notice] = '動画情報取得時にエラーが発生しました。しばらく待ってもう一度更新してください。'
+      return redirect_to :back
+    end
+
     if flv_info[:error]
       msg = "指定された動画取得時にエラーが発生しました。動画ID = #{@id}"
       logger.info "#{msg}, flv_info = #{flv_info.inspect}"
       flash[:notice] = msg
-      redirect_to :back
-      return
+      return redirect_to :back
     end
 
-    if flv_info.has_key? :deleted
+    if flv_info.key? :deleted
       msg = "指定された動画は削除されています。動画ID = #{@id}"
-      logger.info msg + ", flv_info = " + flv_info.inspect
+      logger.info "#{msg}, flv_info = #{flv_info.inspect}"
       flash[:notice] = msg
-      redirect_to :back
-      return
+      return redirect_to :back
     end
         
 


### PR DESCRIPTION
closed のエラーが発生したときApplicationErrorではなく画面にメッセージを表示するようにしました。
